### PR TITLE
Remove project_name field

### DIFF
--- a/service/serviceusers/schemas.go
+++ b/service/serviceusers/schemas.go
@@ -44,10 +44,9 @@ type ServiceUser struct {
 }
 
 type Role struct {
-	ProjectID   string   `json:"project_id,omitempty"`
-	ProjectName string   `json:"project_name,omitempty"`
-	RoleName    RoleName `json:"role_name"`
-	Scope       Scope    `json:"scope"`
+	ProjectID string   `json:"project_id,omitempty"`
+	RoleName  RoleName `json:"role_name"`
+	Scope     Scope    `json:"scope"`
 }
 
 // CreateRequest is used to set options for Create method.

--- a/service/users/schemas.go
+++ b/service/users/schemas.go
@@ -51,10 +51,9 @@ type Federation struct {
 }
 
 type Role struct {
-	ProjectID   string   `json:"project_id,omitempty"`
-	ProjectName string   `json:"project_name,omitempty"`
-	RoleName    RoleName `json:"role_name"`
-	Scope       Scope    `json:"scope"`
+	ProjectID string   `json:"project_id,omitempty"`
+	RoleName  RoleName `json:"role_name"`
+	Scope     Scope    `json:"scope"`
 }
 
 // CreateRequest is used to set options for Create method.


### PR DESCRIPTION
1. Removed `project_name` field, because it's not used in IAM API