### PR TITLE
Add methods for Groups

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,6 +76,13 @@ linters-settings:
   
   nolintlint:
     allow-leading-space: false
+
+  revive:
+    rules:
+      - name: var-naming
+        arguments:
+          # they outplayed themselves, and "IDS" actually means "allow 'Ids' in var name"
+          - [ "IDS" ] # AllowList"
   
   tagliatelle:
     case:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ You can use this library to work with the following objects of the Selectel IAM 
 
 * [users](https://pkg.go.dev/github.com/selectel/iam-go/service/users)
 * [serviceusers](https://pkg.go.dev/github.com/selectel/iam-go/service/serviceusers)
+* [groups](https://pkg.go.dev/github.com/selectel/iam-go/service/groups)
 * [s3credentials](https://pkg.go.dev/github.com/selectel/iam-go/service/s3credentials)
 
 ### Installation

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,7 @@
 This directory contains examples that cover various use cases and functionality for iam-go.
 
 ### Concepts
+- [**Create Group with role and User**](./group-with-user): Create a new Group with role, create and add a User and delete them.
 - [**Create & Delete S3 Credentials**](./s3credentials-create-delete): Create a new S3 Credentials for an existing Service User (ID is needed) and delete it.
 - [**Create, Update & Delete Service User**](./serviceuser-create-update-delete): Create a new Service User, then update it's data and delete it.
 - [**Transfer role from one User to another**](./transfer-role): Find a billing User from all and transfer it's role to another User (ID is needed).

--- a/examples/group-with-user/README.md
+++ b/examples/group-with-user/README.md
@@ -1,0 +1,28 @@
+# Create Group with Role & add User
+
+This example program demonstrates how to manage creating and deleting Group with Roles and Users.
+
+The part of deleting is disabled by `deleteAfterRun` variable.
+
+As an example, the Member Role will be assigned for a new Group.
+
+## Running this example
+
+Running this file will execute the following operations:
+
+1. **Create Group:** Create is used to create a new Group.
+2. **Create User:** Create is used to create a new User.
+3. **Assign Role:** Assign a role to the created Group.
+4. **Update Group:** Updates the Group Name and Description.
+5. **(Delete Group):** _(disabled by default)_ Delete a just-created Group on a previous step.
+6. **(Delete User):** _(disabled by default)_ Delete a just-created User on a previous step.
+
+You should see an output like the following:
+```
+Step 1: Created Group Name: test_group_name ID: 1a2b3c...
+Step 2: Created User ID: 12345_3... Keystone ID: 1a2b3c...
+Step 3: Assigned Role member with scope account to Group ID: 1a2b3c...
+Step 4: Group Name and Description updated to: new_test_group_name and new_group_description
+Step 5: Deleting Group with ID: 1a2b3c...
+Step 6: Deleting User with ID: 12345_3...
+```

--- a/examples/group-with-user/main.go
+++ b/examples/group-with-user/main.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/selectel/iam-go"
+	"github.com/selectel/iam-go/service/groups"
+	"github.com/selectel/iam-go/service/roles"
+	"github.com/selectel/iam-go/service/users"
+)
+
+var (
+	// KeystoneToken
+	token          = "gAAAAA..."
+	deleteAfterRun = false
+
+	// Prefix to be added to User-Agent.
+	prefix = "iam-go"
+
+	groupName          = "test_group_name"
+	description        = "group_description"
+	updatedGroupName   = "new_test_group_name"
+	updatedDescription = "new_group_description"
+	email              = "testmail@example.com"
+)
+
+func main() {
+	// Create a new IAM client.
+	iamClient, err := iam.New(
+		iam.WithAuthOpts(&iam.AuthOpts{KeystoneToken: token}),
+		iam.WithUserAgentPrefix(prefix),
+	)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	usersAPI := iamClient.Users
+	groupsAPI := iamClient.Groups
+	ctx := context.Background()
+
+	group, err := groupsAPI.Create(ctx, groups.CreateRequest{Name: groupName, Description: description})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Printf("Step 1: Created Group Name: %s ID: %s\n", group.Name, group.ID)
+
+	user, err := usersAPI.Create(ctx, users.CreateRequest{
+		AuthType:   users.Local,
+		Email:      email,
+		Federation: nil,
+		Roles:      []roles.Role{{Scope: roles.Account, RoleName: roles.Reader}},
+		GroupIDs:   []string{group.ID},
+	})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Printf("Step 2: Created User ID: %s Keystone ID: %s\n", user.ID, user.KeystoneID)
+
+	err = groupsAPI.AssignRoles(ctx, group.ID, []roles.Role{{Scope: roles.Account, RoleName: roles.Member}})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Step 3: Assigned Role %s with scope %s to Group ID: %s\n", roles.Member, roles.Account, group.ID)
+
+	group, err = groupsAPI.Update(ctx, group.ID, groups.ModifyRequest{Name: updatedGroupName,
+		Description: &updatedDescription})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Printf("Step 4: Group Name and Description updated to: %s and %s\n", group.Name, group.Description)
+
+	if deleteAfterRun {
+		fmt.Printf("Step 5: Deleting Group with ID: %s\n", group.ID)
+		if err = groupsAPI.Delete(ctx, group.ID); err != nil {
+			fmt.Println(err)
+		}
+
+		fmt.Printf("Step 6: Deleting User with ID: %s\n", user.ID)
+		if err = usersAPI.Delete(ctx, user.ID); err != nil {
+			fmt.Println(err)
+		}
+	}
+}

--- a/examples/s3credentials-create-delete/README.md
+++ b/examples/s3credentials-create-delete/README.md
@@ -2,14 +2,14 @@
 
 This example program demonstrates how to manage creating and deleting S3 Credentials for a Service User.
 
-The part of deleting a just-created credentials is commented.
+The part of deleting a just-created credentials is disabled by `deleteAfterRun` variable.
 
 ## Running this example
 
 Running this file will execute the following operations:
 
 1. **Create:** Create is used to create a new S3 Credentials. It is implied, that the Service User ID is known.
-2. **(Delete):** _(commented by default)_ Delete deletes a just-created credentials on a previous step.
+2. **(Delete):** _(disabled by default)_ Delete deletes a just-created credentials on a previous step.
 
 You should see an output like the following (with both operations enabled):
 

--- a/examples/s3credentials-create-delete/main.go
+++ b/examples/s3credentials-create-delete/main.go
@@ -7,22 +7,25 @@ import (
 	iam "github.com/selectel/iam-go"
 )
 
-func main() {
+var (
 	// KeystoneToken
-	token := "gAAAAA..."
+	token          = "gAAAAA..."
+	deleteAfterRun = false
 
 	// Prefix to be added to User-Agent.
-	prefix := "iam-go"
+	prefix = "iam-go"
 
 	// ID of the User to create S3 Credentials for.
-	userID := "a1b2c3..."
+	userID = "a1b2c3..."
 
 	// Name of the S3 Credentials to create.
-	name := "my-s3-credentials"
+	name = "my-s3-credentials"
 
 	// Project ID to create the S3 Credentials for.
-	projectID := "a1b2c3..."
+	projectID = "a1b2c3..."
+)
 
+func main() {
 	// Create a new IAM client.
 	iamClient, err := iam.New(
 		iam.WithAuthOpts(&iam.AuthOpts{KeystoneToken: token}),
@@ -56,16 +59,15 @@ func main() {
 	fmt.Printf("Step 1: Created credentials Secret Key: %s Access Key: %s\n", credentials.SecretKey,
 		credentials.AccessKey)
 
-	// // Delete an existing S3 Credentials.
-	// err = s3CredAPI.Delete(ctx, &s3credentials.DeleteInput{
-	// 	UserID:    userID,
-	// 	AccessKey: credentials.AccessKey,
-	// })
+	if deleteAfterRun {
+		// Delete an existing S3 Credentials.
+		err = s3CredAPI.Delete(ctx, userID, credentials.AccessKey)
 
-	// // Handle the error.
-	// if err != nil {
-	// 	fmt.Println(err)
-	// }
+		// Handle the error.
+		if err != nil {
+			fmt.Println(err)
+		}
 
-	// fmt.Printf("Step 2: Deleted credentials")
+		fmt.Printf("Step 2: Deleted credentials")
+	}
 }

--- a/examples/serviceuser-create-update-delete/README.md
+++ b/examples/serviceuser-create-update-delete/README.md
@@ -2,7 +2,7 @@
 
 This example program demonstrates how to manage creating, updating and deleting Service User.
 
-The part of deleting a just-created Service User is commented.
+The part of deleting a just-created Service User is disabled by `deleteAfterRun` variable.
 
 As an example, the Billing Role will be assigned for a new Service User and in update method this Service User will be set to _Disabled_.
 
@@ -11,8 +11,8 @@ As an example, the Billing Role will be assigned for a new Service User and in u
 Running this file will execute the following operations:
 
 1. **Create:** Create is used to create a new Service User.
-2. **Update** Update sets _Enabled_ property of the just-created Service User to _false_
-3. **(Delete):** _(commented by default)_ Delete deletes a just-created Service User.
+2. **Update:** Update sets _Enabled_ property of the just-created Service User to _false_
+3. **(Delete):** _(disabled by default)_ Delete deletes a just-created Service User.
 
 You should see an output like the following (with all operations enabled):
 

--- a/examples/serviceuser-create-update-delete/main.go
+++ b/examples/serviceuser-create-update-delete/main.go
@@ -9,25 +9,25 @@ import (
 	"github.com/selectel/iam-go/service/serviceusers"
 )
 
-func main() {
+var (
 	// KeystoneToken
-	token := "gAAAAA..."
+	token          = "gAAAAA..."
+	deleteAfterRun = false
 
 	// Prefix to be added to User-Agent.
-	prefix := "iam-go"
-
+	prefix = "iam-go"
 	// Name of the Service User to create.
-	name := "service-user"
-
+	name = "service-user"
 	// Password of the Service User to create.
-	password := "Qazwsxedc123"
+	password = "Qazwsxedc123"
+)
 
+func main() {
 	// Create a new IAM client.
 	iamClient, err := iam.New(
 		iam.WithAuthOpts(&iam.AuthOpts{KeystoneToken: token}),
 		iam.WithUserAgentPrefix(prefix),
 	)
-	// Handle the error.
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -46,7 +46,6 @@ func main() {
 		Password: password,
 		Roles:    []roles.Role{{Scope: roles.Account, RoleName: roles.Billing}},
 	})
-	// Handle the error.
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -58,7 +57,6 @@ func main() {
 	_, err = serviceUsersAPI.Update(ctx, serviceUser.ID, serviceusers.UpdateRequest{
 		Enabled: false,
 	})
-	// Handle the error.
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -66,13 +64,16 @@ func main() {
 
 	fmt.Printf("Step 2: Disabled Service User ID %s\n", serviceUser.ID)
 
-	// // Delete an existing Service User.
-	// err = serviceUsersAPI.Delete(ctx, serviceUser.ID)
+	// Disabled by default
+	if deleteAfterRun {
+		// Delete an existing Service User.
+		err = serviceUsersAPI.Delete(ctx, serviceUser.ID)
 
-	// // Handle the error.
-	// if err != nil {
-	// 	fmt.Println(err)
-	// }
+		// Handle the error.
+		if err != nil {
+			fmt.Println(err)
+		}
 
-	// fmt.Printf("Step 3: Deleted Service User ID %s\n", serviceUser.ID)
+		fmt.Printf("Step 3: Deleted Service User ID %s\n", serviceUser.ID)
+	}
 }

--- a/examples/transfer-role/README.md
+++ b/examples/transfer-role/README.md
@@ -10,7 +10,7 @@ Running this file will execute the following operations:
 
 1. **List:** List is used to retrieve all Users. The first one, who has a billing role, will be selected as 'transferer'.
 2. **UnassignRole:** UnassinRole will remove Billing role from chosen user.
-3. **AssignRole** AssignRole will add Billing role to the predefined User ID.
+3. **AssignRole:** AssignRole will add Billing role to the predefined User ID.
 
 You should see an output like the following:
 

--- a/examples/transfer-role/main.go
+++ b/examples/transfer-role/main.go
@@ -43,7 +43,7 @@ func main() {
 		return
 	}
 
-	var chosenUser *users.User
+	var chosenUser *users.UserListResponse
 	for _, user := range allUsers {
 		for _, role := range user.Roles {
 			if role.RoleName == roles.Billing && user.ID != "account_root" {

--- a/examples/user-create-delete/README.md
+++ b/examples/user-create-delete/README.md
@@ -2,7 +2,7 @@
 
 This example program demonstrates how to manage creating and deleting User.
 
-The part of deleting a just-created User is commented.
+The part of deleting a just-created User is disabled by `deleteAfterRun` variable.
 
 As an example, the Billing Role will be assigned for a new User.
 

--- a/examples/user-create-delete/main.go
+++ b/examples/user-create-delete/main.go
@@ -9,16 +9,19 @@ import (
 	"github.com/selectel/iam-go/service/users"
 )
 
-func main() {
+var (
 	// KeystoneToken
-	token := "gAAAAA..."
+	token          = "gAAAAA..."
+	deleteAfterRun = false
 
 	// Prefix to be added to User-Agent.
-	prefix := "iam-go"
+	prefix = "iam-go"
 
 	// Email of the User to create.
-	email := "testmail@mail.com"
+	email = "testmail@example.com"
+)
 
+func main() {
 	// Create a new IAM client.
 	iamClient, err := iam.New(
 		iam.WithAuthOpts(&iam.AuthOpts{KeystoneToken: token}),
@@ -51,13 +54,15 @@ func main() {
 
 	fmt.Printf("Step 1: Created User ID: %s Keystone ID: %s\n", user.ID, user.KeystoneID)
 
-	// // Delete an existing User.
-	// err = usersAPI.Delete(ctx, user.ID)
+	if deleteAfterRun {
+		// Delete an existing User.
+		err = usersAPI.Delete(ctx, user.ID)
 
-	// // Handle the error.
-	// if err != nil {
-	// 	fmt.Println(err)
-	// }
+		// Handle the error.
+		if err != nil {
+			fmt.Println(err)
+		}
 
-	// fmt.Printf("Step 2: Deleted User ID: %s", user.ID)
+		fmt.Printf("Step 2: Deleted User ID: %s", user.ID)
+	}
 }

--- a/iam.go
+++ b/iam.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/selectel/iam-go/iamerrors"
 	baseclient "github.com/selectel/iam-go/internal/client"
+	"github.com/selectel/iam-go/service/groups"
 	"github.com/selectel/iam-go/service/s3credentials"
 	"github.com/selectel/iam-go/service/serviceusers"
 	"github.com/selectel/iam-go/service/users"
@@ -50,6 +51,9 @@ type Client struct {
 
 	// ServiceUsers instance is used to make requests against Selectel IAM API and manage Service Users.
 	ServiceUsers *serviceusers.ServiceUsers
+
+	// Groups instance is used to make requests against Selectel IAM API and manage Groups of users.
+	Groups *groups.Groups
 
 	// S3Credentials instance is used to make requests against Selectel IAM API and manage S3 Credentials.
 	S3Credentials *s3credentials.S3Credentials
@@ -122,6 +126,7 @@ func New(opts ...Option) (*Client, error) {
 
 	c.Users = users.New(c.baseClient)
 	c.ServiceUsers = serviceusers.New(c.baseClient)
+	c.Groups = groups.New(c.baseClient)
 	c.S3Credentials = s3credentials.New(c.baseClient)
 
 	return c, nil

--- a/iam_test.go
+++ b/iam_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/selectel/iam-go/iamerrors"
 	baseclient "github.com/selectel/iam-go/internal/client"
+	"github.com/selectel/iam-go/service/groups"
 	"github.com/selectel/iam-go/service/s3credentials"
 	"github.com/selectel/iam-go/service/serviceusers"
 	"github.com/selectel/iam-go/service/users"
@@ -59,6 +60,7 @@ func TestNew(t *testing.T) {
 					baseClient:    baseClient,
 					Users:         users.New(baseClient),
 					ServiceUsers:  serviceusers.New(baseClient),
+					Groups:        groups.New(baseClient),
 					S3Credentials: s3credentials.New(baseClient),
 				}
 			},
@@ -100,6 +102,7 @@ func TestNew(t *testing.T) {
 					baseClient:    baseClient,
 					Users:         users.New(baseClient),
 					ServiceUsers:  serviceusers.New(baseClient),
+					Groups:        groups.New(baseClient),
 					S3Credentials: s3credentials.New(baseClient),
 				}
 			},
@@ -134,6 +137,7 @@ func TestNew(t *testing.T) {
 					baseClient:    baseClient,
 					Users:         users.New(baseClient),
 					ServiceUsers:  serviceusers.New(baseClient),
+					Groups:        groups.New(baseClient),
 					S3Credentials: s3credentials.New(baseClient),
 				}
 			},

--- a/iamerrors/iamerrors.go
+++ b/iamerrors/iamerrors.go
@@ -21,6 +21,14 @@ var (
 
 	ErrUserIDRequired    = errors.New("USER_ID_REQUIRED")
 	ErrProjectIDRequired = errors.New("PROJECT_ID_REQUIRED")
+	ErrGroupIDRequired   = errors.New("GROUP_ID_REQUIRED")
+
+	ErrGroupNameRequired    = errors.New("GROUP_NAME_REQUIRED")
+	ErrGroupRolesRequired   = errors.New("GROUP_ROLES_REQUIRED")
+	ErrGroupUserIDsRequired = errors.New("GROUP_USER_IDS_REQUIRED")
+	ErrGroupAlreadyExists   = errors.New("GROUP_ALREADY_EXISTS")
+	ErrGroupNotFound        = errors.New("GROUP_NOT_FOUND")
+	ErrUserOrGroupNotFound  = errors.New("USER_OR_GROUP_NOT_FOUND")
 
 	ErrCredentialNameRequired      = errors.New("CREDENTIAL_NAME_REQUIRED")
 	ErrCredentialAccessKeyRequired = errors.New("CREDENTIAL_ACCESS_KEY_REQUIRED")
@@ -55,6 +63,13 @@ var (
 		ErrCredentialAccessKeyRequired.Error(): ErrCredentialAccessKeyRequired,
 		ErrUserIDRequired.Error():              ErrUserIDRequired,
 		ErrProjectIDRequired.Error():           ErrProjectIDRequired,
+		ErrGroupIDRequired.Error():             ErrGroupIDRequired,
+		ErrGroupUserIDsRequired.Error():        ErrGroupUserIDsRequired,
+		ErrGroupNameRequired.Error():           ErrGroupNameRequired,
+		ErrGroupRolesRequired.Error():          ErrGroupRolesRequired,
+		ErrGroupAlreadyExists.Error():          ErrGroupAlreadyExists,
+		ErrGroupNotFound.Error():               ErrGroupNotFound,
+		ErrUserOrGroupNotFound.Error():         ErrUserOrGroupNotFound,
 		ErrServiceUserNameRequired.Error():     ErrServiceUserNameRequired,
 		ErrServiceUserPasswordRequired.Error(): ErrServiceUserPasswordRequired,
 		ErrServiceUserRolesRequired.Error():    ErrServiceUserRolesRequired,

--- a/service/groups/doc.go
+++ b/service/groups/doc.go
@@ -1,0 +1,2 @@
+// Package groups provides a set of functions for interacting with the Selectel Groups API.
+package groups

--- a/service/groups/requests_test.go
+++ b/service/groups/requests_test.go
@@ -1,0 +1,683 @@
+package groups
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/selectel/iam-go/iamerrors"
+	"github.com/selectel/iam-go/internal/client"
+	"github.com/selectel/iam-go/service/groups/testdata"
+	"github.com/selectel/iam-go/service/roles"
+	"github.com/selectel/iam-go/service/users"
+)
+
+const (
+	groupsURL   = "iam/v1/groups"
+	groupsIDURL = "iam/v1/groups/123"
+	rolesURL    = "iam/v1/groups/123/roles"
+	usersURL    = "iam/v1/groups/123/users"
+)
+
+func TestList(t *testing.T) {
+	tests := []struct {
+		name             string
+		prepare          func()
+		expectedResponse []GroupListResponse
+		expectedError    error
+	}{
+		{
+			name: "ok",
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodGet, testdata.TestURL+groupsURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusOK, testdata.TestListGroupsResponse)
+						return resp, nil
+					})
+			},
+			expectedResponse: []GroupListResponse{
+				{
+					ID:          "123",
+					Name:        "test_name",
+					Description: "test_description",
+					Roles: []roles.Role{
+						{Scope: roles.Account, RoleName: roles.Member},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "error",
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodGet, testdata.TestURL+groupsURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusForbidden, testdata.TestDoRequestErr)
+						return resp, nil
+					})
+			},
+			expectedResponse: nil,
+			expectedError:    iamerrors.ErrForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			groupsAPI := New(&client.BaseClient{
+				HTTPClient: &http.Client{},
+				APIUrl:     testdata.TestURL,
+				AuthMethod: &client.KeystoneTokenAuth{KeystoneToken: testdata.TestToken},
+			})
+
+			httpmock.ActivateNonDefault(groupsAPI.baseClient.HTTPClient)
+			defer httpmock.DeactivateAndReset()
+
+			tt.prepare()
+
+			ctx := context.Background()
+			actual, err := groupsAPI.List(ctx)
+
+			require.ErrorIs(err, tt.expectedError)
+
+			assert.Equal(tt.expectedResponse, actual)
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	type args struct {
+		groupID string
+	}
+	tests := []struct {
+		name             string
+		args             args
+		prepare          func()
+		expectedResponse *Group
+		expectedError    error
+	}{
+		{
+			name: "ok",
+			args: args{
+				groupID: "123",
+			},
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodGet, testdata.TestURL+groupsIDURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusOK, testdata.TestGetGroupResponse)
+						return resp, nil
+					})
+			},
+			expectedResponse: &Group{
+				ID:          "123",
+				Name:        "test_name",
+				Description: "test_description",
+				Roles: []roles.Role{
+					{Scope: roles.Account, RoleName: roles.Member},
+				},
+				ServiceUsers: []ServiceUser{
+					{
+						Name:    "1234",
+						Enabled: false,
+						ID:      "c1f50a57fc95438aafe1e2fe87a781c2",
+					},
+				},
+				Users: []User{{
+					AuthType: users.Federated,
+					Federation: &users.Federation{
+						ID:         "674870b5-6ad1-478e-8384-2527507fd85d",
+						ExternalID: "asdfasdf",
+					},
+					ID:         "999000_33333",
+					KeystoneID: "2b573185f23a40c88cbb59ed74dba683",
+				}},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "error",
+			args: args{
+				groupID: "123",
+			},
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodGet, testdata.TestURL+groupsIDURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusForbidden, testdata.TestDoRequestErr)
+						return resp, nil
+					})
+			},
+			expectedResponse: nil,
+			expectedError:    iamerrors.ErrForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			groupsAPI := New(&client.BaseClient{
+				HTTPClient: &http.Client{},
+				APIUrl:     testdata.TestURL,
+				AuthMethod: &client.KeystoneTokenAuth{KeystoneToken: testdata.TestToken},
+			})
+
+			httpmock.ActivateNonDefault(groupsAPI.baseClient.HTTPClient)
+			defer httpmock.DeactivateAndReset()
+
+			tt.prepare()
+
+			ctx := context.Background()
+			actual, err := groupsAPI.Get(ctx, tt.args.groupID)
+
+			require.ErrorIs(err, tt.expectedError)
+
+			assert.Equal(tt.expectedResponse, actual)
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	type args struct {
+		groupID string
+	}
+	tests := []struct {
+		name          string
+		args          args
+		prepare       func()
+		expectedError error
+	}{
+		{
+			name: "ok",
+			args: args{
+				groupID: "123",
+			},
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodDelete, testdata.TestURL+groupsIDURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusNoContent, "")
+						return resp, nil
+					})
+			},
+			expectedError: nil,
+		},
+		{
+			name: "error",
+			args: args{
+				groupID: "123",
+			},
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodDelete, testdata.TestURL+groupsIDURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusForbidden, testdata.TestDoRequestErr)
+						return resp, nil
+					})
+			},
+			expectedError: iamerrors.ErrForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			groupsAPI := New(&client.BaseClient{
+				HTTPClient: &http.Client{},
+				APIUrl:     testdata.TestURL,
+				AuthMethod: &client.KeystoneTokenAuth{KeystoneToken: testdata.TestToken},
+			})
+
+			httpmock.ActivateNonDefault(groupsAPI.baseClient.HTTPClient)
+			defer httpmock.DeactivateAndReset()
+
+			tt.prepare()
+
+			ctx := context.Background()
+			err := groupsAPI.Delete(ctx, tt.args.groupID)
+
+			require.ErrorIs(err, tt.expectedError)
+		})
+	}
+}
+
+func TestCreate(t *testing.T) {
+	type args struct {
+		name        string
+		description string
+	}
+	tests := []struct {
+		name             string
+		args             args
+		prepare          func()
+		expectedResponse *Group
+		expectedError    error
+	}{
+		{
+			name: "ok",
+			args: args{
+				name:        "test_name",
+				description: "test_description",
+			},
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodPost, testdata.TestURL+groupsURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusOK, testdata.TestCreateGroupResponse)
+						return resp, nil
+					})
+			},
+			expectedResponse: &Group{
+				ID:           "123",
+				Name:         "test_name",
+				Description:  "test_description",
+				Roles:        []roles.Role{},
+				ServiceUsers: []ServiceUser{},
+				Users:        []User{},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "error",
+			args: args{
+				name:        "test_name",
+				description: "test_description",
+			},
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodPost, testdata.TestURL+groupsURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusForbidden, testdata.TestDoRequestErr)
+						return resp, nil
+					})
+			},
+			expectedResponse: nil,
+			expectedError:    iamerrors.ErrForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			groupsAPI := New(&client.BaseClient{
+				HTTPClient: &http.Client{},
+				APIUrl:     testdata.TestURL,
+				AuthMethod: &client.KeystoneTokenAuth{KeystoneToken: testdata.TestToken},
+			})
+
+			httpmock.ActivateNonDefault(groupsAPI.baseClient.HTTPClient)
+			defer httpmock.DeactivateAndReset()
+
+			tt.prepare()
+			ctx := context.Background()
+
+			actual, err := groupsAPI.Create(ctx, CreateRequest{
+				Name:        tt.args.name,
+				Description: tt.args.description,
+			})
+			require.ErrorIs(err, tt.expectedError)
+			assert.Equal(tt.expectedResponse, actual)
+		})
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	type args struct {
+		groupID     string
+		name        string
+		description *string
+	}
+	testDescription := "test_description"
+	tests := []struct {
+		name             string
+		args             args
+		prepare          func()
+		expectedResponse *Group
+		expectedError    error
+	}{
+		{
+			name: "ok",
+			args: args{
+				groupID:     "123",
+				name:        "test_name",
+				description: &testDescription,
+			},
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodPatch, testdata.TestURL+groupsIDURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusOK, testdata.TestCreateGroupResponse)
+						return resp, nil
+					})
+			},
+			expectedResponse: &Group{
+				ID:           "123",
+				Name:         "test_name",
+				Description:  "test_description",
+				Roles:        []roles.Role{},
+				ServiceUsers: []ServiceUser{},
+				Users:        []User{},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "error",
+			args: args{
+				groupID:     "123",
+				name:        "test_name",
+				description: &testDescription,
+			},
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodPatch, testdata.TestURL+groupsIDURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusForbidden, testdata.TestDoRequestErr)
+						return resp, nil
+					})
+			},
+			expectedResponse: nil,
+			expectedError:    iamerrors.ErrForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			groupsAPI := New(&client.BaseClient{
+				HTTPClient: &http.Client{},
+				APIUrl:     testdata.TestURL,
+				AuthMethod: &client.KeystoneTokenAuth{KeystoneToken: testdata.TestToken},
+			})
+
+			httpmock.ActivateNonDefault(groupsAPI.baseClient.HTTPClient)
+			defer httpmock.DeactivateAndReset()
+
+			tt.prepare()
+			ctx := context.Background()
+
+			actual, err := groupsAPI.Update(ctx, tt.args.groupID, ModifyRequest{
+				Name:        tt.args.name,
+				Description: tt.args.description,
+			})
+			require.ErrorIs(err, tt.expectedError)
+			assert.Equal(tt.expectedResponse, actual)
+		})
+	}
+}
+
+func TestAssignRoles(t *testing.T) {
+	type args struct {
+		groupID string
+		roles   []roles.Role
+	}
+	tests := []struct {
+		name          string
+		args          args
+		prepare       func()
+		expectedError error
+	}{
+		{
+			name: "ok",
+			args: args{
+				groupID: "123",
+				roles: []roles.Role{
+					{Scope: roles.Account, RoleName: roles.Member},
+				},
+			},
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodPut, testdata.TestURL+rolesURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusNoContent, "")
+						return resp, nil
+					})
+			},
+			expectedError: nil,
+		},
+		{
+			name: "error",
+			args: args{
+				groupID: "123",
+				roles: []roles.Role{
+					{Scope: roles.Account, RoleName: roles.Member},
+				},
+			},
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodPut, testdata.TestURL+rolesURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusForbidden, testdata.TestDoRequestErr)
+						return resp, nil
+					})
+			},
+			expectedError: iamerrors.ErrForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			groupsAPI := New(&client.BaseClient{
+				HTTPClient: &http.Client{},
+				APIUrl:     testdata.TestURL,
+				AuthMethod: &client.KeystoneTokenAuth{KeystoneToken: testdata.TestToken},
+			})
+
+			httpmock.ActivateNonDefault(groupsAPI.baseClient.HTTPClient)
+			defer httpmock.DeactivateAndReset()
+
+			tt.prepare()
+
+			ctx := context.Background()
+			err := groupsAPI.AssignRoles(ctx, tt.args.groupID, tt.args.roles)
+
+			require.ErrorIs(err, tt.expectedError)
+		})
+	}
+}
+
+func TestUnassignRoles(t *testing.T) {
+	type args struct {
+		groupID string
+		roles   []roles.Role
+	}
+	tests := []struct {
+		name          string
+		args          args
+		prepare       func()
+		expectedError error
+	}{
+		{
+			name: "ok",
+			args: args{
+				groupID: "123",
+				roles: []roles.Role{
+					{Scope: roles.Account, RoleName: roles.Member},
+				},
+			},
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodDelete, testdata.TestURL+rolesURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusNoContent, "")
+						return resp, nil
+					})
+			},
+			expectedError: nil,
+		},
+		{
+			name: "error",
+			args: args{
+				groupID: "123",
+				roles: []roles.Role{
+					{Scope: roles.Account, RoleName: roles.Member},
+				},
+			},
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodDelete, testdata.TestURL+rolesURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusForbidden, testdata.TestDoRequestErr)
+						return resp, nil
+					})
+			},
+			expectedError: iamerrors.ErrForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			groupsAPI := New(&client.BaseClient{
+				HTTPClient: &http.Client{},
+				APIUrl:     testdata.TestURL,
+				AuthMethod: &client.KeystoneTokenAuth{KeystoneToken: testdata.TestToken},
+			})
+
+			httpmock.ActivateNonDefault(groupsAPI.baseClient.HTTPClient)
+			defer httpmock.DeactivateAndReset()
+
+			tt.prepare()
+
+			ctx := context.Background()
+			err := groupsAPI.UnassignRoles(ctx, tt.args.groupID, tt.args.roles)
+
+			require.ErrorIs(err, tt.expectedError)
+		})
+	}
+}
+
+func TestAddUsers(t *testing.T) {
+	type args struct {
+		groupID  string
+		usersIDs []string
+	}
+	tests := []struct {
+		name          string
+		args          args
+		prepare       func()
+		expectedError error
+	}{
+		{
+			name: "ok",
+			args: args{
+				groupID:  "123",
+				usersIDs: []string{"user123"},
+			},
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodPut, testdata.TestURL+usersURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusNoContent, "")
+						return resp, nil
+					})
+			},
+			expectedError: nil,
+		},
+		{
+			name: "error",
+			args: args{
+				groupID:  "123",
+				usersIDs: []string{"user123"},
+			},
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodPut, testdata.TestURL+usersURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusForbidden, testdata.TestDoRequestErr)
+						return resp, nil
+					})
+			},
+			expectedError: iamerrors.ErrForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			groupsAPI := New(&client.BaseClient{
+				HTTPClient: &http.Client{},
+				APIUrl:     testdata.TestURL,
+				AuthMethod: &client.KeystoneTokenAuth{KeystoneToken: testdata.TestToken},
+			})
+
+			httpmock.ActivateNonDefault(groupsAPI.baseClient.HTTPClient)
+			defer httpmock.DeactivateAndReset()
+
+			tt.prepare()
+
+			ctx := context.Background()
+			err := groupsAPI.AddUsers(ctx, tt.args.groupID, tt.args.usersIDs)
+
+			require.ErrorIs(err, tt.expectedError)
+		})
+	}
+}
+
+func TestDeleteUsers(t *testing.T) {
+	type args struct {
+		groupID  string
+		usersIDs []string
+	}
+	tests := []struct {
+		name          string
+		args          args
+		prepare       func()
+		expectedError error
+	}{
+		{
+			name: "ok",
+			args: args{
+				groupID:  "123",
+				usersIDs: []string{"user123"},
+			},
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodDelete, testdata.TestURL+usersURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusNoContent, "")
+						return resp, nil
+					})
+			},
+			expectedError: nil,
+		},
+		{
+			name: "error",
+			args: args{
+				groupID:  "123",
+				usersIDs: []string{"user123"},
+			},
+			prepare: func() {
+				httpmock.RegisterResponder(
+					http.MethodDelete, testdata.TestURL+usersURL, func(r *http.Request) (*http.Response, error) {
+						resp := httpmock.NewStringResponse(http.StatusForbidden, testdata.TestDoRequestErr)
+						return resp, nil
+					})
+			},
+			expectedError: iamerrors.ErrForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			groupsAPI := New(&client.BaseClient{
+				HTTPClient: &http.Client{},
+				APIUrl:     testdata.TestURL,
+				AuthMethod: &client.KeystoneTokenAuth{KeystoneToken: testdata.TestToken},
+			})
+
+			httpmock.ActivateNonDefault(groupsAPI.baseClient.HTTPClient)
+			defer httpmock.DeactivateAndReset()
+
+			tt.prepare()
+
+			ctx := context.Background()
+			err := groupsAPI.DeleteUsers(ctx, tt.args.groupID, tt.args.usersIDs)
+
+			require.ErrorIs(err, tt.expectedError)
+		})
+	}
+}

--- a/service/groups/schemas.go
+++ b/service/groups/schemas.go
@@ -1,0 +1,63 @@
+package groups
+
+import (
+	"github.com/selectel/iam-go/service/roles"
+	"github.com/selectel/iam-go/service/users"
+)
+
+type listResponse struct {
+	Groups []GroupListResponse `json:"groups"`
+}
+
+// GroupListResponse represents a Group in list response.
+type GroupListResponse struct {
+	ID          string       `json:"id"`
+	Name        string       `json:"name"`
+	Description string       `json:"description"`
+	Roles       []roles.Role `json:"roles"`
+}
+
+// Group represents a Group of users.
+type Group struct {
+	ID           string        `json:"id"`
+	Name         string        `json:"name"`
+	Description  string        `json:"description"`
+	Roles        []roles.Role  `json:"roles"`
+	ServiceUsers []ServiceUser `json:"service_users"`
+	Users        []User        `json:"users"`
+}
+
+// ServiceUser represents a Selectel Service User in Group.
+type ServiceUser struct {
+	ID      string `json:"id"`
+	Enabled bool   `json:"enabled"`
+	Name    string `json:"name"`
+}
+
+// User represents a Selectel Panel User in Group.
+type User struct {
+	AuthType   users.AuthType    `json:"auth_type"`
+	Federation *users.Federation `json:"federation,omitempty"`
+	ID         string            `json:"id"`
+	KeystoneID string            `json:"keystone_id"`
+}
+
+// CreateRequest is used to set options for Create method.
+type CreateRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// ModifyRequest is used as options for Update method.
+type ModifyRequest struct {
+	Name        string  `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+}
+
+type manageRolesRequest struct {
+	Roles []roles.Role `json:"roles"`
+}
+
+type manageUsersRequest struct {
+	KeystoneIds []string `json:"keystone_ids"`
+}

--- a/service/groups/testdata/fixtures.go
+++ b/service/groups/testdata/fixtures.go
@@ -1,0 +1,100 @@
+package testdata
+
+const (
+	TestToken = "test-token"
+	TestURL   = "http://example.org/"
+)
+
+const TestListGroupsResponse = `{
+	"groups": [
+		{
+			"id": "123",
+			"name": "test_name",
+			"description": "test_description",
+			"roles": [
+				{
+					"scope": "account",
+					"role_name": "member"
+				}
+			]
+		}
+	]
+}`
+
+const TestGetGroupResponse = `{
+	"id": "123",
+	"name": "test_name",
+	"description": "test_description",
+	"roles": [
+				{
+					"scope": "account",
+					"role_name": "member"
+				}
+			],
+	"users": [
+		{
+			"auth_type": "federated",
+			"federation": {
+				"id": "674870b5-6ad1-478e-8384-2527507fd85d",
+				"external_id": "asdfasdf"
+			},
+			"id": "999000_33333",
+			"keystone_id": "2b573185f23a40c88cbb59ed74dba683",
+			"roles": null
+		}
+	],
+	"service_users": [
+		{
+			"name": "1234",
+			"enabled": false,
+			"id": "c1f50a57fc95438aafe1e2fe87a781c2",
+			"roles": null
+		}
+	]
+}`
+
+const TestCreateGroupResponse = `{
+	"id": "123",
+	"name": "test_name",
+	"description": "test_description",
+	"roles": [],
+	"users": [],
+	"service_users": []
+}`
+
+const TestUpdateGroupResponse = `{
+	"id": "123",
+	"name": "test_name",
+	"description": "test_description",
+	"roles":  [
+				{
+					"scope": "account",
+					"role_name": "member"
+				}
+			],
+	"users": [
+		{
+			"auth_type": "federated",
+			"federation": {
+				"id": "674870b5-6ad1-478e-8384-2527507fd85d",
+				"external_id": "asdfasdf"
+			},
+			"id": "999000_33333",
+			"keystone_id": "2b573185f23a40c88cbb59ed74dba683",
+			"roles": null
+		}
+	],
+	"service_users": [
+		{
+			"name": "1234",
+			"enabled": false,
+			"id": "c1f50a57fc95438aafe1e2fe87a781c2",
+			"roles": null
+		}
+	]
+}`
+
+const TestDoRequestErr = `{
+	"code": "REQUEST_FORBIDDEN",
+	"message": "You don't have permission to do this"
+}`

--- a/service/serviceusers/requests.go
+++ b/service/serviceusers/requests.go
@@ -27,7 +27,7 @@ func New(baseClient *client.BaseClient) *ServiceUsers {
 }
 
 // List returns a list of Service Users for the account.
-func (su *ServiceUsers) List(ctx context.Context) ([]ServiceUser, error) {
+func (su *ServiceUsers) List(ctx context.Context) ([]ServiceUserListResponse, error) {
 	path, err := url.JoinPath(apiVersion, "service_users")
 	if err != nil {
 		return nil, iamerrors.Error{Err: iamerrors.ErrInternalAppError, Desc: err.Error()}
@@ -81,7 +81,7 @@ func (su *ServiceUsers) Get(ctx context.Context, userID string) (*ServiceUser, e
 }
 
 // Create creates a new Service User.
-func (su *ServiceUsers) Create(ctx context.Context, input CreateRequest) (*ServiceUser, error) {
+func (su *ServiceUsers) Create(ctx context.Context, input CreateRequest) (*CreateResponse, error) {
 	if input.Name == "" {
 		return nil, iamerrors.Error{
 			Err: iamerrors.ErrServiceUserNameRequired, Desc: "No name for Service User was provided.",
@@ -101,6 +101,7 @@ func (su *ServiceUsers) Create(ctx context.Context, input CreateRequest) (*Servi
 		Enabled:  input.Enabled,
 		Name:     input.Name,
 		Password: input.Password,
+		GroupIds: input.GroupIDs,
 		Roles:    input.Roles,
 	})
 	if err != nil {
@@ -117,7 +118,7 @@ func (su *ServiceUsers) Create(ctx context.Context, input CreateRequest) (*Servi
 		return nil, err
 	}
 
-	var createdUser ServiceUser
+	var createdUser CreateResponse
 	err = client.UnmarshalJSON(response, &createdUser)
 	if err != nil {
 		return nil, iamerrors.Error{Err: iamerrors.ErrInternalAppError, Desc: err.Error()}

--- a/service/serviceusers/requests_test.go
+++ b/service/serviceusers/requests_test.go
@@ -25,19 +25,19 @@ func TestList(t *testing.T) {
 	tests := []struct {
 		name             string
 		prepare          func()
-		expectedResponse []ServiceUser
+		expectedResponse []ServiceUserListResponse
 		expectedError    error
 	}{
 		{
-			name: "Test List return output",
+			name: "ok",
 			prepare: func() {
 				httpmock.RegisterResponder(
 					http.MethodGet, testdata.TestURL+serviceUsersURL, func(r *http.Request) (*http.Response, error) {
-						resp := httpmock.NewStringResponse(http.StatusOK, testdata.TestGetUsersResponse)
+						resp := httpmock.NewStringResponse(http.StatusOK, testdata.TestListUsersResponse)
 						return resp, nil
 					})
 			},
-			expectedResponse: []ServiceUser{
+			expectedResponse: []ServiceUserListResponse{
 				{
 					Name:    "test",
 					Enabled: true,
@@ -50,7 +50,7 @@ func TestList(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name: "Test List return error",
+			name: "error",
 			prepare: func() {
 				httpmock.RegisterResponder(
 					http.MethodGet, testdata.TestURL+serviceUsersURL, func(r *http.Request) (*http.Response, error) {
@@ -118,6 +118,9 @@ func TestGet(t *testing.T) {
 				ID:      "123",
 				Roles: []roles.Role{
 					{Scope: roles.Account, RoleName: roles.Member},
+				},
+				Groups: []Group{
+					{Name: "123", ID: "96a60e7b9e9e48308eed46269f9a147b", Roles: []roles.Role{}},
 				},
 			},
 			expectedError: nil,
@@ -242,7 +245,7 @@ func TestCreate(t *testing.T) {
 		name             string
 		args             args
 		prepare          func()
-		expectedResponse *ServiceUser
+		expectedResponse *CreateResponse
 		expectedError    error
 	}{
 		{
@@ -262,7 +265,7 @@ func TestCreate(t *testing.T) {
 						return resp, nil
 					})
 			},
-			expectedResponse: &ServiceUser{
+			expectedResponse: &CreateResponse{
 				Name:    "test",
 				Enabled: true,
 				ID:      "123",

--- a/service/serviceusers/schemas.go
+++ b/service/serviceusers/schemas.go
@@ -2,12 +2,33 @@ package serviceusers
 
 import "github.com/selectel/iam-go/service/roles"
 
+type listResponse struct {
+	Users []ServiceUserListResponse `json:"users"`
+}
+
+// ServiceUserListResponse represents a Selectel Service Users in list response.
+type ServiceUserListResponse struct {
+	ID      string       `json:"id"`
+	Enabled bool         `json:"enabled"`
+	Name    string       `json:"name"`
+	Roles   []roles.Role `json:"roles"`
+}
+
 // ServiceUser represents a Selectel Service User.
 type ServiceUser struct {
 	ID      string       `json:"id"`
 	Enabled bool         `json:"enabled"`
 	Name    string       `json:"name"`
 	Roles   []roles.Role `json:"roles"`
+	Groups  []Group      `json:"groups"`
+}
+
+// Group represents a Group for users.
+type Group struct {
+	ID          string       `json:"id"`
+	Name        string       `json:"name"`
+	Description string       `json:"description"`
+	Roles       []roles.Role `json:"roles"`
 }
 
 // CreateRequest is used to set options for Create method.
@@ -15,7 +36,15 @@ type CreateRequest struct {
 	Enabled  bool
 	Name     string
 	Password string
+	GroupIDs []string
 	Roles    []roles.Role
+}
+
+type CreateResponse struct {
+	ID      string       `json:"id"`
+	Enabled bool         `json:"enabled"`
+	Name    string       `json:"name"`
+	Roles   []roles.Role `json:"roles"`
 }
 
 // UpdateRequest is used to set options for Update method.
@@ -29,6 +58,7 @@ type createRequest struct {
 	Enabled  bool         `json:"enabled,omitempty"`
 	Name     string       `json:"name,omitempty"`
 	Password string       `json:"password,omitempty"`
+	GroupIds []string     `json:"group_ids,omitempty"`
 	Roles    []roles.Role `json:"roles,omitempty"`
 }
 
@@ -40,8 +70,4 @@ type updateRequest struct {
 
 type manageRolesRequest struct {
 	Roles []roles.Role `json:"roles"`
-}
-
-type listResponse struct {
-	Users []ServiceUser `json:"users"`
 }

--- a/service/serviceusers/testdata/fixtures.go
+++ b/service/serviceusers/testdata/fixtures.go
@@ -5,7 +5,7 @@ const (
 	TestURL   = "http://example.org/"
 )
 
-const TestGetUsersResponse = `{
+const TestListUsersResponse = `{
     "users": [
         {
             "name": "test",
@@ -29,6 +29,14 @@ const TestGetUserResponse = `{
 		{
 			"scope": "account",
 			"role_name": "member"
+		}
+	],
+	"groups": [
+		{
+			"id": "96a60e7b9e9e48308eed46269f9a147b",
+			"name": "123",
+			"description": "",
+			"roles": []
 		}
 	]
 }`

--- a/service/users/requests.go
+++ b/service/users/requests.go
@@ -27,7 +27,7 @@ func New(baseClient *client.BaseClient) *Users {
 }
 
 // List returns a list of Users for the account.
-func (u *Users) List(ctx context.Context) ([]User, error) {
+func (u *Users) List(ctx context.Context) ([]UserListResponse, error) {
 	path, err := url.JoinPath(apiVersion, "users")
 	if err != nil {
 		return nil, iamerrors.Error{Err: iamerrors.ErrInternalAppError, Desc: err.Error()}
@@ -81,7 +81,7 @@ func (u *Users) Get(ctx context.Context, userID string) (*User, error) {
 }
 
 // Create creates a new User.
-func (u *Users) Create(ctx context.Context, input CreateRequest) (*User, error) {
+func (u *Users) Create(ctx context.Context, input CreateRequest) (*CreateResponse, error) {
 	if input.Email == "" {
 		return nil, iamerrors.Error{Err: iamerrors.ErrUserEmailRequired, Desc: "No email for User was provided."}
 	}
@@ -96,6 +96,7 @@ func (u *Users) Create(ctx context.Context, input CreateRequest) (*User, error) 
 		Email:             input.Email,
 		Federation:        input.Federation,
 		Roles:             input.Roles,
+		GroupIds:          input.GroupIDs,
 		SubscriptionsOnly: false,      // Issue, should be hardcoded
 		Subscriptions:     []string{}, // Issue, should be hardcoded
 	})
@@ -113,7 +114,7 @@ func (u *Users) Create(ctx context.Context, input CreateRequest) (*User, error) 
 		return nil, err
 	}
 
-	var createdUser User
+	var createdUser CreateResponse
 	err = client.UnmarshalJSON(response, &createdUser)
 	if err != nil {
 		return nil, iamerrors.Error{Err: iamerrors.ErrInternalAppError, Desc: err.Error()}

--- a/service/users/requests_test.go
+++ b/service/users/requests_test.go
@@ -26,7 +26,7 @@ func TestList(t *testing.T) {
 	tests := []struct {
 		name             string
 		prepare          func()
-		expectedResponse []User
+		expectedResponse []UserListResponse
 		expectedError    error
 	}{
 		{
@@ -34,11 +34,11 @@ func TestList(t *testing.T) {
 			prepare: func() {
 				httpmock.RegisterResponder(
 					http.MethodGet, testdata.TestURL+usersURL, func(r *http.Request) (*http.Response, error) {
-						resp := httpmock.NewStringResponse(http.StatusOK, testdata.TestGetUsersResponse)
+						resp := httpmock.NewStringResponse(http.StatusOK, testdata.TestListUsersResponse)
 						return resp, nil
 					})
 			},
-			expectedResponse: []User{
+			expectedResponse: []UserListResponse{
 				{
 					AuthType:   "local",
 					KeystoneID: "123",
@@ -119,6 +119,9 @@ func TestGet(t *testing.T) {
 				ID:         "123",
 				Roles: []roles.Role{
 					{Scope: roles.Account, RoleName: roles.Member},
+				},
+				Groups: []Group{
+					{Name: "123", ID: "96a60e7b9e9e48308eed46269f9a147b", Roles: []roles.Role{}},
 				},
 			},
 			expectedError: nil,
@@ -240,7 +243,7 @@ func TestCreate(t *testing.T) {
 		name             string
 		args             args
 		prepare          func()
-		expectedResponse *User
+		expectedResponse *CreateResponse
 		expectedError    error
 	}{
 		{
@@ -263,7 +266,7 @@ func TestCreate(t *testing.T) {
 						return resp, nil
 					})
 			},
-			expectedResponse: &User{
+			expectedResponse: &CreateResponse{
 				AuthType: "federated",
 				Federation: &Federation{
 					ExternalID: "123",

--- a/service/users/schemas.go
+++ b/service/users/schemas.go
@@ -1,6 +1,8 @@
 package users
 
-import "github.com/selectel/iam-go/service/roles"
+import (
+	"github.com/selectel/iam-go/service/roles"
+)
 
 // AuthType represents a type of authentication of a User.
 type AuthType string
@@ -13,8 +15,12 @@ const (
 	Federated AuthType = "federated"
 )
 
-// User represents a Selectel Panel User.
-type User struct {
+type listResponse struct {
+	Users []UserListResponse `json:"users"`
+}
+
+// UserListResponse represents a Selectel User in list response.
+type UserListResponse struct {
 	AuthType   AuthType     `json:"auth_type"`
 	Federation *Federation  `json:"federation,omitempty"`
 	Roles      []roles.Role `json:"roles"`
@@ -22,9 +28,29 @@ type User struct {
 	KeystoneID string       `json:"keystone_id"`
 }
 
+// User represents a Selectel Panel User.
+type User struct {
+	AuthType   AuthType     `json:"auth_type"`
+	Federation *Federation  `json:"federation,omitempty"`
+	Roles      []roles.Role `json:"roles"`
+	ID         string       `json:"id"`
+	KeystoneID string       `json:"keystone_id"`
+	Groups     []Group      `json:"groups"`
+}
+
 type Federation struct {
+	// ExternalID is user id that will be sent by the identity provider.
 	ExternalID string `json:"external_id"`
-	ID         string `json:"id"`
+	// ID represents identifier of federation in Selectel
+	ID string `json:"id"`
+}
+
+// Group represents a Group for users.
+type Group struct {
+	ID          string       `json:"id"`
+	Name        string       `json:"name"`
+	Description string       `json:"description"`
+	Roles       []roles.Role `json:"roles"`
 }
 
 // CreateRequest is used to set options for Create method.
@@ -33,6 +59,7 @@ type CreateRequest struct {
 	Email      string
 	Federation *Federation
 	Roles      []roles.Role
+	GroupIDs   []string
 }
 
 type createRequest struct {
@@ -40,14 +67,19 @@ type createRequest struct {
 	Email             string       `json:"email,omitempty"`
 	Federation        *Federation  `json:"federation,omitempty"`
 	Roles             []roles.Role `json:"roles,omitempty"`
+	GroupIds          []string     `json:"group_ids,omitempty"`
 	SubscriptionsOnly bool         `json:"subscriptions_only"` // Issue, should be hardcoded to `false`
 	Subscriptions     []string     `json:"subscriptions"`      // Issue, should be hardcoded to `[]`
 }
 
-type manageRolesRequest struct {
-	Roles []roles.Role `json:"roles"`
+type CreateResponse struct {
+	AuthType   AuthType     `json:"auth_type"`
+	Federation *Federation  `json:"federation,omitempty"`
+	Roles      []roles.Role `json:"roles"`
+	ID         string       `json:"id"`
+	KeystoneID string       `json:"keystone_id"`
 }
 
-type listResponse struct {
-	Users []User `json:"users"`
+type manageRolesRequest struct {
+	Roles []roles.Role `json:"roles"`
 }

--- a/service/users/testdata/fixtures.go
+++ b/service/users/testdata/fixtures.go
@@ -5,7 +5,7 @@ const (
 	TestURL   = "http://example.org/"
 )
 
-const TestGetUsersResponse = `{
+const TestListUsersResponse = `{
 	"users": [
 		{
 			"auth_type": "local",
@@ -30,7 +30,15 @@ const TestGetUserResponse = `{
             "scope": "account",
             "role_name": "member"
         }
-    ]
+    ],
+	"groups": [
+		{
+			"id": "96a60e7b9e9e48308eed46269f9a147b",
+			"name": "123",
+			"description": "",
+			"roles": []
+		}
+	]
 }`
 
 const TestCreateUserResponse = `{


### PR DESCRIPTION
Added methods for managing Groups, their roles and users in them.

The Users and Service Users structs are extended with Groups.
The **changes are backwards incompatible** because now different structs are used for different kinds of requests.