### PR TITLE
fix: add `alias` field to SAML create request schema

### DIFF
--- a/service/federations/saml/schemas.go
+++ b/service/federations/saml/schemas.go
@@ -35,6 +35,7 @@ type GetResponse struct {
 type CreateRequest struct {
 	Name               string `json:"name"`
 	Description        string `json:"description"`
+	Alias              string `json:"alias,omitempty"`
 	Issuer             string `json:"issuer"`
 	SSOUrl             string `json:"sso_url"`
 	SignAuthnRequests  bool   `json:"sign_authn_requests,omitempty"`


### PR DESCRIPTION
- add missing field `alias` to SAML create request schema